### PR TITLE
fix: validation of varint encoding

### DIFF
--- a/encode/wire-types.js
+++ b/encode/wire-types.js
@@ -55,7 +55,7 @@ const varint = {
     const high = Number(BigInt(int) >> 32n)
     return (9 * (32 - Math.clz32(high) + 32) + 64) / 64 | 0
   },
-  MIN_VALUE: 0n,
+  MIN_VALUE: -(1n << 63n),
   MAX_VALUE: (1n << 64n) - 1n
 }
 


### PR DESCRIPTION
Varint values should be in the range of int64 min value. to uint64 max value